### PR TITLE
Taskserver: Add user and group to the service module.

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -234,6 +234,7 @@
       #lxd = 210; # unused
       kibana = 211;
       xtreemfs = 212;
+      taskd = 213;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -446,7 +447,7 @@
       lxd = 210; # unused
       #kibana = 211;
       xtreemfs = 212;
-      taskserver = 213;
+      taskd = 213;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/services/misc/taskserver.nix
+++ b/nixos/modules/services/misc/taskserver.nix
@@ -16,6 +16,11 @@ in {
         description = "User for taskserver.";
       };
 
+      group = mkOption {
+        default = "taskd";
+        description = "Group for taskserver.";
+      };
+
       dataDir = mkOption {
         default = "/var/lib/taskserver/data/";
         description = "Data directory for taskserver.";
@@ -183,6 +188,18 @@ in {
 
     environment.systemPackages = [ pkgs.taskserver ];
 
+    users.users = optional (cfg.user == "taskd") {
+      name = "taskd";
+      uid = config.ids.uids.taskd;
+      description = "Taskserver user";
+      group = cfg.group;
+    };
+
+    users.groups = optional (cfg.group == "taskd") {
+      name = "taskd";
+      gid = config.ids.gids.taskd;
+    };
+
     systemd.services.taskserver = {
       description = "taskserver Service.";
       path = [ pkgs.taskserver ];
@@ -223,6 +240,7 @@ in {
         ExecStart = "${pkgs.taskserver}/bin/taskdctl start";
         ExecStop  = "${pkgs.taskserver}/bin/taskdctl stop";
         User = cfg.user;
+        Group = cfg.group;
       };
     };
   };


### PR DESCRIPTION
Addresses NixOS/nixpkgs#7771.

Please note that this doesn't yet fix all problems. First, the `preStart` script needs to be run as root (you can either use `serviceConfig.PermissionsStartOnly` or another `oneshot` service, or even a `path` service), because the `taskd` user can't create the data directory. Second, there is another error with the `pki` command (`pkgs.taskserver` doesn't have `$taskserver/pki`).
